### PR TITLE
Fix serialization of datetime object to JSON

### DIFF
--- a/aws_export_credentials/aws_export_credentials.py
+++ b/aws_export_credentials/aws_export_credentials.py
@@ -494,7 +494,7 @@ class IMDSRequestHandler(BaseHTTPRequestHandler):
                     body['Expiration'] = serialize_date(credentials.Expiration)
                 else:
                     # An expiration is required
-                    body['Expiration'] = datetime.now(tz=timezone.utc) + timedelta(minutes=60)
+                    body['Expiration'] = serialize_date(datetime.now(tz=timezone.utc) + timedelta(minutes=60))
                 return self.send_ok("application/json", body)
         return self.send_error(
             HTTPStatus.NOT_FOUND,


### PR DESCRIPTION
The exception below was thrown when invoking `self.send_ok` from `IMDSRequestHandler.do_GET`:

```
  File "/opt/homebrew/lib/python3.10/site-packages/aws_export_credentials/aws_export_credentials.py", line 423, in send_ok
    body = json.dumps(body).encode("utf-8")
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

Environment:
- Python version: 3.10.8 (installed via homebrew)
- OS: macOS 12.6
- Arch: ARM M1