### PR TITLE
Update Credentials for new version boto3

### DIFF
--- a/aws_export_credentials/aws_export_credentials.py
+++ b/aws_export_credentials/aws_export_credentials.py
@@ -30,7 +30,7 @@ import subprocess
 
 from boto3 import Session
 
-__version__ = '0.18.0' # Update here and pyproject.toml
+__version__ = '0.19.0' # Update here and pyproject.toml
 
 LOGGER = logging.getLogger('aws-export-credentials')
 
@@ -47,7 +47,7 @@ TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 Credentials = namedtuple('Credentials', ['AccessKeyId', 'SecretAccessKey', 'SessionToken', 'Expiration'])
 def convert_creds(read_only_creds, expiration=None):
-    return Credentials(*list(read_only_creds) + [expiration])
+    return Credentials(read_only_creds.access_key, read_only_creds.secret_key, read_only_creds.token, expiration)
 
 def parse_container_arg(value):
     token = value[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-export-credentials"
-version = "0.18.0" # Update here and aws_export_credentials.py
+version = "0.19.0" # Update here and aws_export_credentials.py
 description = "Get AWS credentials from a profile to inject into other programs"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
boto3 v.1.37 and above added  new `account_id` as parameter and `read_only_creds` now returns also `account_id`

so now it is 6 params instead of 5.

This PR will fix `Credentials.__new__() takes 5 positional arguments but 6 were given`

